### PR TITLE
Adding an other event to bind with checkValue

### DIFF
--- a/floatlabels.js
+++ b/floatlabels.js
@@ -75,7 +75,7 @@
                 if( !settings.slideInput ) {                    
                     thisElement.css({ 'padding-top' : this.inputPaddingTop });
                 }
-                thisElement.on('keyup blur change', function( e ) {
+                thisElement.on('keydown keyup blur change', function( e ) {
                     self.checkValue( e );
                 });
                 thisElement.on('blur', function() { thisElement.prev('label').css({ 'color' : self.settings.blurColor }); });


### PR DESCRIPTION
Put `checkValue()` function to trigger also on keydown. When you hold backspace until the end of the input value, it will show both, floatlabel and placeholder. If you check in both events "keyup and keydown" it will be good.
